### PR TITLE
add rate limiting to testnet upow endpoints

### DIFF
--- a/ex/lib/http/multiserver.ex
+++ b/ex/lib/http/multiserver.ex
@@ -4,6 +4,7 @@ defmodule Ama.MultiServer do
             :socket_ack -> :ok
         after 3000 -> throw(:no_socket_passed) end
 
+        HTTP.RateLimiter.setup()
         state = Map.put(state, :request, %{buf: <<>>})
         :ok = :inet.setopts(state.socket, [{:active, :once}])
         loop_http(state)
@@ -46,6 +47,21 @@ defmodule Ama.MultiServer do
     def quick_reply(state, reply, status_code \\ 200) do
         :ok = :gen_tcp.send(state.socket, Photon.HTTP.Response.build_cors(state.request, status_code, %{}, reply))
         state
+    end
+
+    defp client_ip(socket) do
+        case :inet.peername(socket) do
+            {:ok, {ip, _port}} -> ip
+            _ -> :unknown
+        end
+    end
+
+    defp rate_limited_reply(state, limit, window_ms, content_fn) do
+        ip = client_ip(state.socket)
+        case HTTP.RateLimiter.check(ip, limit, window_ms) do
+            :ok -> content_fn.()
+            :rate_limited -> quick_reply(state, JSX.encode!(%{error: :rate_limited}), 429)
+        end
     end
 
     defp prometheus_reply(state, content_fn) do
@@ -305,25 +321,29 @@ defmodule Ama.MultiServer do
                 quick_reply(%{state|request: r}, result)
 
             testnet and r.method == "GET" and r.path == "/api/upow/seed" ->
-              epoch = DB.Chain.epoch()
-              segment_vr_hash = DB.Chain.segment_vr_hash()
-              nonce = :crypto.strong_rand_bytes(12)
-              %{pk: pk, pop: pop} = Application.fetch_env!(:ama, :keys) |> hd()
-              seed = <<epoch::32-little, segment_vr_hash::32-binary,
-                pk::48-binary, pop::96-binary, pk::binary, nonce::12-binary>>
-              quick_reply(state, seed)
+              rate_limited_reply(state, 10, 60_000, fn ->
+                epoch = DB.Chain.epoch()
+                segment_vr_hash = DB.Chain.segment_vr_hash()
+                nonce = :crypto.strong_rand_bytes(12)
+                %{pk: pk, pop: pop} = Application.fetch_env!(:ama, :keys) |> hd()
+                seed = <<epoch::32-little, segment_vr_hash::32-binary,
+                  pk::48-binary, pop::96-binary, pk::binary, nonce::12-binary>>
+                quick_reply(state, seed)
+              end)
 
             testnet and r.method == "GET" and r.path == "/api/upow/seed_with_matrix_a_b" ->
-              epoch = DB.Chain.epoch()
-              segment_vr_hash = DB.Chain.segment_vr_hash()
-              nonce = :crypto.strong_rand_bytes(12)
-              %{pk: pk, pop: pop} = Application.fetch_env!(:ama, :keys) |> hd()
-              seed = <<epoch::32-little, segment_vr_hash::32-binary,
-                pk::48-binary, pop::96-binary, pk::binary, nonce::12-binary>>
-              b = Blake3.new()
-              Blake3.update(b, seed)
-              matrix_a_b = Blake3.finalize_xof(b, 16*50240 + 50240*16)
-              quick_reply(state, seed <> matrix_a_b)
+              rate_limited_reply(state, 2, 60_000, fn ->
+                epoch = DB.Chain.epoch()
+                segment_vr_hash = DB.Chain.segment_vr_hash()
+                nonce = :crypto.strong_rand_bytes(12)
+                %{pk: pk, pop: pop} = Application.fetch_env!(:ama, :keys) |> hd()
+                seed = <<epoch::32-little, segment_vr_hash::32-binary,
+                  pk::48-binary, pop::96-binary, pk::binary, nonce::12-binary>>
+                b = Blake3.new()
+                Blake3.update(b, seed)
+                matrix_a_b = Blake3.finalize_xof(b, 16*50240 + 50240*16)
+                quick_reply(state, seed <> matrix_a_b)
+              end)
 
             testnet and r.method == "GET" and String.starts_with?(r.path, "/api/upow/validate/") ->
               sol = String.replace(r.path, "/api/upow/validate/", "") |> Base58.decode()

--- a/ex/lib/http/rate_limiter.ex
+++ b/ex/lib/http/rate_limiter.ex
@@ -1,0 +1,26 @@
+defmodule HTTP.RateLimiter do
+  @table :http_rate_limiter
+
+  def setup do
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set])
+    end
+  end
+
+  # Returns :ok or :rate_limited
+  def check(ip, limit, window_ms) do
+    now = System.monotonic_time(:millisecond)
+    case :ets.lookup(@table, ip) do
+      [{^ip, count, window_start}] when now - window_start < window_ms ->
+        if count >= limit do
+          :rate_limited
+        else
+          :ets.insert(@table, {ip, count + 1, window_start})
+          :ok
+        end
+      _ ->
+        :ets.insert(@table, {ip, 1, now})
+        :ok
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`/api/upow/seed_with_matrix_a_b` returns ~16MB of matrix data per request with no rate limiting. Anyone can abuse it for bandwidth exhaustion on testnet nodes.

## Changes

- New `HTTP.RateLimiter` module — simple ETS-based per-IP sliding window counter
- `/api/upow/seed` — max **10 req/min** per IP
- `/api/upow/seed_with_matrix_a_b` — max **2 req/min** per IP
- Returns HTTP **429** when limit exceeded

## Notes

- Only affects testnet (endpoints gated by `:testnet` flag as before)
- No new dependencies — uses built-in `:ets`
- Mainnet is not affected